### PR TITLE
Add madarco/agentbox to VM & microVM platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ AI coding agents are useful precisely because they can read files, run commands,
 
 ### Multiplatform
 
+- [AgentBox](https://github.com/madarco/agentbox) - Run coding agents (Claude Code, Codex, OpenCode) in parallel across sandboxed VMs (local Docker, self-hosted, or cloud: Hetzner, Daytona, Vercel, E2B, DigitalOcean) with sub-second checkpoints, per-box browser/VS Code/shells, and git credentials kept on the host.
 - [boxed](https://github.com/akshayaggarwal99/boxed) - Code-execution engine for untrusted agent code across Docker, Firecracker, and Wasm.
 - [boxlite-labs/boxlite](https://github.com/boxlite-labs/boxlite) - Closely related BoxLite implementation under a different org namespace.
 - [BoxLite](https://github.com/boxlite-ai/boxlite) - Embeddable VM-style sandboxing with snapshots and persistent state.


### PR DESCRIPTION
Adds [madarco/agentbox](https://github.com/madarco/agentbox) to **Virtual machines and microVM platforms → Multiplatform** (placed alphabetically first).

Note: the list already contains an unrelated `rcarmo/agentbox` (a personal-setup writeup), so this is a distinct project — I've used the `madarco/agentbox` link text to disambiguate. AgentBox runs coding agents (Claude Code, Codex, OpenCode) in parallel across sandboxed VMs (local Docker, self-hosted, or cloud) with sub-second checkpoints and git credentials kept on the host. MIT.